### PR TITLE
Switch to the Rise typeface

### DIFF
--- a/source/stylesheets/_variables.scss
+++ b/source/stylesheets/_variables.scss
@@ -20,20 +20,18 @@ under the License.
 ////////////////////////////////////////////////////////////////////////////////
 // Use these settings to help adjust the appearance of Slate
 
-// Thumbtack Mark Font
+// Thumbtack Rise Font
 
 @font-face {
-    font-family: 'Mark';
-    font-weight: 400;
-    src: url(https://fonts.thumbtack.com/mark/mark-tt.woff2) format('woff2'),
-        url(https://fonts.thumbtack.com/mark/mark-tt.woff) format('woff');
-}
+    font-family: Rise;
+    src:
+        url('https://fonts.thumbtack.com/thumbtack-rise/ThumbtackRiseVF.woff2')
+            format('woff2-variations'),
+        url('https://fonts.thumbtack.com/thumbtack-rise/ThumbtackRiseVF.woff')
+            format('woff-variations');
 
-@font-face {
-    font-family: 'Mark';
-    font-weight: 700;
-    src: url(https://fonts.thumbtack.com/mark/mark-tt-bold.woff2) format('woff2'),
-        url(https://fonts.thumbtack.com/mark/mark-tt-bold.woff) format('woff');
+    // The font looks broken on mobile Safari without this line.
+    font-weight: 100 900;
 }
 
 // BACKGROUND COLORS
@@ -85,7 +83,7 @@ $phone-width: $tablet-width - $nav-width !default; // min width before reverting
 // FONTS
 ////////////////////
 %default-font {
-    font-family: Mark, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+    font-family: Rise, Avenir, Helvetica, Arial, sans-serif;
     font-size: 14px;
 }
 


### PR DESCRIPTION
Thumbtack is moving away from the TTMark typeface in favor of Rise. I'm going through all of our web codebases and making the change.